### PR TITLE
remove different filter options, prefer single query 

### DIFF
--- a/addon/components/model-select.js
+++ b/addon/components/model-select.js
@@ -5,7 +5,6 @@ import { assert} from '@ember/debug';
 import { isEmpty} from '@ember/utils';
 import { computed, get, set } from '@ember/object';
 import { inject as service } from '@ember/service';
-import { assign } from '@ember/polyfills';
 
 import { task, timeout } from 'ember-concurrency';
 import fallbackIfUndefined from '../utils/computed-fallback-if-undefined';
@@ -195,7 +194,8 @@ export default Component.extend({
       yield timeout(this.get('debounceDuration'));
     }
 
-    const query = assign({}, this.get('query'));
+    // query might be an EmptyObject/{{hash}}, make it a normal Object
+    const query = JSON.parse(JSON.stringify(this.get('query')));
 
     if(term){
       const searchProperty = this.get('searchProperty');

--- a/addon/components/model-select.js
+++ b/addon/components/model-select.js
@@ -195,7 +195,7 @@ export default Component.extend({
     }
 
     // query might be an EmptyObject/{{hash}}, make it a normal Object
-    const query = JSON.parse(JSON.stringify(this.get('query')));
+    const query = JSON.parse(JSON.stringify(this.get('query'))) || {};
 
     if(term){
       const searchProperty = this.get('searchProperty');

--- a/addon/components/model-select.js
+++ b/addon/components/model-select.js
@@ -97,15 +97,6 @@ export default Component.extend({
   pageSize: fallbackIfUndefined(25),
 
   /**
-   * An optional filter which will be added to the query done to the API. Can be used to limit query results.
-   *
-   * @argument filter
-   * @type Object
-   * @default null
-   */
-  filter: fallbackIfUndefined(null),
-
-  /**
    * An optional query which will be merged with the rest of the query done to the API. Can be used to sort etc.
    *
    * @argument query
@@ -113,25 +104,6 @@ export default Component.extend({
    * @default null
    */
   query: fallbackIfUndefined(null),
-
-  /**
-   * An optional filter key. Can be used when just a single property needs to be filtered. Will work together with
-   * `filter` and also takes precedence over it.
-   *
-   * @argument filterKey
-   * @type String
-   * @default null
-   */
-  filterKey: fallbackIfUndefined(null),
-
-  /**
-   * An optional filter value. Used as the value for the `filterKey`.
-   *
-   * @argument filterValue
-   * @type String|Number
-   * @default null
-   */
-  filterValue: fallbackIfUndefined(null),
 
   /**
    * Whether or not the model-search-box is disabled.
@@ -224,11 +196,6 @@ export default Component.extend({
     }
 
     const query = assign({}, this.get('query'));
-    query.filter = assign({}, this.get('filter'));
-
-    if(this.get('filterKey') && !isEmpty(this.get('filterValue'))){
-      query.filter[this.get('filterKey')] = this.get('filterValue');
-    }
 
     if(term){
       const searchProperty = this.get('searchProperty');

--- a/tests/integration/components/model-select-test.js
+++ b/tests/integration/components/model-select-test.js
@@ -71,11 +71,8 @@ module('Integration | Component | model-select', function(hooks) {
 
     this.element.querySelector('.ember-power-select-options').scrollTop = 999;
 
-
-    //TODO: test if spinner appears
-
     //TODO: see if we can do this in a neater way
-    await timeout(1);
+    await timeout(100);
     await settled();
 
     assert.dom('.ember-power-select-option').exists({ count: 50 });

--- a/tests/integration/components/model-select-test.js
+++ b/tests/integration/components/model-select-test.js
@@ -91,8 +91,6 @@ module('Integration | Component | model-select', function(hooks) {
 
     this.element.querySelector('.ember-power-select-options').scrollTop = 999;
 
-    //TODO: see if we can do this in a neater way
-    await timeout(1);
     await settled();
 
     assert.dom('.ember-power-select-option').exists({ count: 25 });

--- a/tests/integration/components/model-select-test.js
+++ b/tests/integration/components/model-select-test.js
@@ -14,6 +14,8 @@ module('Integration | Component | model-select', function(hooks) {
   setupMirage(hooks);
 
   test('it renders', async function(assert) {
+    assert.expect(1);
+
     defaultScenario(this.server);
 
     await render(hbs`{{model-select modelName='user' labelProperty='name'}}`);
@@ -24,6 +26,7 @@ module('Integration | Component | model-select', function(hooks) {
 
   test('it respects the page size option', async function(assert) {
     assert.expect(1);
+
     defaultScenario(this.server);
 
     await render(hbs`{{model-select modelName='user' labelProperty='name' pageSize=10}}`);
@@ -34,19 +37,19 @@ module('Integration | Component | model-select', function(hooks) {
 
   test('it limits shown results based on search', async function(assert) {
     assert.expect(1);
+
     defaultScenario(this.server);
 
-    await render(hbs`{{model-select modelName='user' labelProperty='name'}}`);
+    await render(hbs`{{model-select modelName='user' labelProperty='name' searchProperty="filter"}}`);
     await clickTrigger('.ember-model-select');
     await typeInSearch('asdasdasd');
-
-    await settled();
 
     assert.dom('.ember-power-select-option').exists({ count: 1 });
   });
 
   test('it triggers the onChange hook when an option is selected', async function(assert) {
     assert.expect(1);
+
     defaultScenario(this.server);
 
     let handleClick = this.spy();
@@ -60,6 +63,7 @@ module('Integration | Component | model-select', function(hooks) {
 
   test('it loads more options when scrolling down', async function(assert) {
     assert.expect(1);
+
     defaultScenario(this.server);
 
     await render(hbs`{{model-select modelName='user' labelProperty='name' renderInPlace=true}}`);
@@ -79,6 +83,7 @@ module('Integration | Component | model-select', function(hooks) {
 
   test('it does not load more options when scrolling down and infiniteLoading is false', async function(assert) {
     assert.expect(1);
+
     defaultScenario(this.server);
 
     await render(hbs`{{model-select modelName='user' labelProperty='name' renderInPlace=true infiniteScroll=false}}`);

--- a/tests/integration/components/model-select-test.js
+++ b/tests/integration/components/model-select-test.js
@@ -72,7 +72,7 @@ module('Integration | Component | model-select', function(hooks) {
     this.element.querySelector('.ember-power-select-options').scrollTop = 999;
 
     //TODO: see if we can do this in a neater way
-    await timeout(100);
+    await timeout(500);
     await settled();
 
     assert.dom('.ember-power-select-option').exists({ count: 50 });


### PR DESCRIPTION
(i.e. using hash helper) to be more API agnostic