### PR TITLE
show loading state when search task is running

### DIFF
--- a/addon/templates/components/model-select.hbs
+++ b/addon/templates/components/model-select.hbs
@@ -1,5 +1,5 @@
 {{#model-select/power-select
-  afterOptionsComponent=afterOptionsComponent
+  afterOptionsComponent=(component afterOptionsComponent loading=searchModels.isRunning)
   allowClear=allowClear
   animationEnabled=animationEnabled
   ariaDescribedBy=ariaDescribedBy


### PR DESCRIPTION
loading spinner was not showing on initial load

thanks to @tomlankhorst