### PR TITLE
Fix: frozen loading after item selection

### DIFF
--- a/addon/components/model-select.js
+++ b/addon/components/model-select.js
@@ -300,6 +300,10 @@ export default class ModelSelectComponent extends Component {
     let _options;
 
     if (this.infiniteScroll) {
+      if (this._selectedModel) {
+        this._options = null;
+      }
+
       // ember-infinity configuration
       query.perPage = this.pageSize;
 


### PR DESCRIPTION
## FIX 
### Before: 
after select of item load task was not resolving causing constant loading state
### Current behaviour: 
after select options are enabled to be loaded